### PR TITLE
feat(website): add user-facing changelog with plain english descriptions

### DIFF
--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -2,14 +2,14 @@
 
 Updates and improvements to make your research easier and more efficient.
 
-## Version 1.1.0 - June 16, 2025
+## [1.1.0] - 2025-06-16
 
 ### New Features
 - **Changelog Page**: You can now view all updates and improvements directly on the website
   - Check out the "Changelog" link in the navigation menu to see what's new
   - See both user-friendly summaries and detailed technical changes
 
-## Version 1.0.1 - June 15, 2025
+## [1.0.1] - 2025-06-15
 
 ### New Features
 - **Better Infrastructure**: Behind-the-scenes improvements for faster, more reliable service
@@ -23,7 +23,7 @@ Updates and improvements to make your research easier and more efficient.
 ### Bug Fixes
 - **Chrome Extension**: Fixed authentication issues that could prevent search results from uploading properly
 
-## Version 1.0.0 - January 15, 2025
+## [1.0.0] - 2025-01-15
 
 ### Initial Release
 - **Complete Survey System**: Create, edit, and manage research surveys with multiple question types

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -1,0 +1,34 @@
+# What's New in Morphic
+
+Updates and improvements to make your research easier and more efficient.
+
+## Version 1.1.0 - June 16, 2025
+
+### New Features
+- **Changelog Page**: You can now view all updates and improvements directly on the website
+  - Check out the "Changelog" link in the navigation menu to see what's new
+  - See both user-friendly summaries and detailed technical changes
+
+## Version 1.0.1 - June 15, 2025
+
+### New Features
+- **Better Infrastructure**: Behind-the-scenes improvements for faster, more reliable service
+  - Automated builds ensure you always get the latest stable version
+  - Enhanced security for Chrome extension data uploads
+
+### Improvements
+- **Simplified Setup**: Easier deployment and configuration for administrators
+- **Better Organization**: Streamlined codebase makes future improvements faster to deliver
+
+### Bug Fixes
+- **Chrome Extension**: Fixed authentication issues that could prevent search results from uploading properly
+
+## Version 1.0.0 - January 15, 2025
+
+### Initial Release
+- **Complete Survey System**: Create, edit, and manage research surveys with multiple question types
+- **Google Images Integration**: Automatically collect search results using our Chrome extension
+- **Interactive Maps**: Click-and-drag location picker for geographic surveys
+- **Data Export**: Download your survey results and collected images as CSV files
+- **Secure Access**: User accounts with secure login and data protection
+- **Real-time Progress**: Watch your search results come in as the extension works

--- a/website/src/app/changelog/changelog.component.html
+++ b/website/src/app/changelog/changelog.component.html
@@ -8,7 +8,45 @@
       </nav>
     </div>
     <div class="card-body">
-      <h1 class="mb-4">Morphic Changelog</h1>
+      <div class="d-flex justify-content-between align-items-start mb-4">
+        <h1 class="mb-0">
+          <span *ngIf="!showTechnicalDetails">What's New in Morphic</span>
+          <span *ngIf="showTechnicalDetails">
+            {{ getSelectedComponentName() }} Changelog
+          </span>
+        </h1>
+        <div class="form-check form-switch">
+          <input 
+            class="form-check-input" 
+            type="checkbox" 
+            id="technicalToggle"
+            [(ngModel)]="showTechnicalDetails"
+            (change)="toggleView()"
+            [disabled]="loading">
+          <label class="form-check-label" for="technicalToggle">
+            Show technical details
+          </label>
+        </div>
+      </div>
+      
+      <!-- Component Navigation (Technical Mode Only) -->
+      <div *ngIf="showTechnicalDetails && !loading" class="mb-4">
+        <ul class="nav nav-pills">
+          <li class="nav-item" *ngFor="let component of components">
+            <button 
+              type="button"
+              class="nav-link"
+              [class.active]="selectedComponent === component.id"
+              (click)="selectComponent(component.id)"
+              [attr.aria-current]="selectedComponent === component.id ? 'page' : null">
+              <div class="d-flex flex-column align-items-start">
+                <span class="fw-semibold">{{ component.name }}</span>
+                <small class="text-muted">{{ component.description }}</small>
+              </div>
+            </button>
+          </li>
+        </ul>
+      </div>
       
       <!-- Loading State -->
       <div *ngIf="loading" class="text-center py-5">

--- a/website/src/app/changelog/changelog.component.ts
+++ b/website/src/app/changelog/changelog.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 interface ChangelogEntry {
   text: string;
@@ -22,7 +23,7 @@ interface Changelog {
 
 @Component({
   selector: 'app-changelog',
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './changelog.component.html',
   styleUrl: './changelog.component.css'
 })
@@ -30,6 +31,15 @@ export class ChangelogComponent implements OnInit {
   changelog: Changelog | null = null;
   loading = true;
   error: string | null = null;
+  showTechnicalDetails = false;
+  selectedComponent = 'morphic';
+  
+  components = [
+    { id: 'morphic', name: 'Main Project', description: 'Infrastructure & Deployment' },
+    { id: 'service', name: 'Morphic Service', description: 'Morphic Cloud System' },
+    { id: 'website', name: 'Website', description: 'Morphic Website' },
+    { id: 'extension', name: 'Browser Extension', description: 'Morphic Browser Extension' }
+  ];
   
   constructor(private http: HttpClient) {}
   
@@ -38,7 +48,10 @@ export class ChangelogComponent implements OnInit {
   }
   
   loadChangelog(): void {
-    this.http.get<Changelog>('/changelogs/morphic.json')
+    const changelogFile = this.showTechnicalDetails ? `${this.selectedComponent}.json` : 'user.json';
+    this.loading = true;
+    
+    this.http.get<Changelog>(`/changelogs/${changelogFile}`)
       .subscribe({
         next: (data) => {
           this.changelog = data;
@@ -50,6 +63,23 @@ export class ChangelogComponent implements OnInit {
           console.error('Error loading changelog:', err);
         }
       });
+  }
+  
+  toggleView(): void {
+    if (this.showTechnicalDetails) {
+      this.selectedComponent = 'morphic'; // Default to main project in technical mode
+    }
+    this.loadChangelog();
+  }
+  
+  selectComponent(componentId: string): void {
+    this.selectedComponent = componentId;
+    this.loadChangelog();
+  }
+  
+  getSelectedComponentName(): string {
+    const component = this.components.find(c => c.id === this.selectedComponent);
+    return component?.name || 'Technical';
   }
   
   getSectionKeys(sections: { [key: string]: ChangelogEntry[] }): string[] {


### PR DESCRIPTION
## Summary
- Add user-facing changelog (USER_CHANGELOG.md) with plain english descriptions of updates
- Create toggle functionality to switch between user-friendly and technical changelog views
- Add component navigation in technical mode to browse all system changelogs
- Integrate GitHub source file links in technical changelogs
- Improve component descriptions with user-friendly language

## Features
- **Default user view**: "What's New in Morphic" with accessible language for end users
- **Technical toggle**: Switch to view detailed technical changelogs for all components
- **Component navigation**: Browse Main Project, Morphic Service, Website, and Browser Extension changelogs
- **GitHub integration**: Direct links to source changelog files in technical mode
- **Responsive design**: Clean Bootstrap UI with nav pills and toggle switch

## Changes
- **USER_CHANGELOG.md**: New user-facing changelog with plain english descriptions
- **Build script**: Enhanced to process user changelog and inject GitHub links
- **Angular component**: Added toggle functionality and component navigation
- **UI improvements**: User-friendly component descriptions and better navigation

## Test plan
- [x] User-facing changelog displays by default with plain english
- [x] Toggle switch works correctly between user and technical views  
- [x] Component navigation allows browsing all technical changelogs
- [x] GitHub links work correctly in technical mode descriptions
- [x] Responsive design works on different screen sizes
- [ ] Verify production build processes user changelog correctly
- [ ] Test that new changelog entries appear after running build:assets