### PR TITLE
fix(website): use all.json as single source for changelog data

### DIFF
--- a/website/scripts/process-changelogs.js
+++ b/website/scripts/process-changelogs.js
@@ -179,9 +179,8 @@ function processChangelogs() {
       const userContent = fs.readFileSync(userChangelogPath, 'utf8');
       const userParsed = parseChangelogMarkdown(userContent, 'user');
       
-      // Save user changelog separately
-      const userOutputPath = path.join(OUTPUT_DIR, 'user.json');
-      fs.writeFileSync(userOutputPath, JSON.stringify(userParsed, null, 2));
+      // Add user changelog to combined data
+      processedChangelogs['user'] = userParsed;
       
       console.log(`✓ Processed user-facing changelog (${userParsed.versions.length} versions)`);
     } else {

--- a/website/src/app/changelog/changelog.component.ts
+++ b/website/src/app/changelog/changelog.component.ts
@@ -48,13 +48,13 @@ export class ChangelogComponent implements OnInit {
   }
   
   loadChangelog(): void {
-    const changelogFile = this.showTechnicalDetails ? `${this.selectedComponent}.json` : 'user.json';
     this.loading = true;
     
-    this.http.get<Changelog>(`/changelogs/${changelogFile}`)
+    this.http.get<{[key: string]: Changelog}>('/changelogs/all.json')
       .subscribe({
         next: (data) => {
-          this.changelog = data;
+          const componentKey = this.showTechnicalDetails ? this.selectedComponent : 'user';
+          this.changelog = data[componentKey];
           this.loading = false;
         },
         error: (err) => {


### PR DESCRIPTION
## Summary
- Consolidate changelog data into single all.json file instead of multiple individual files
- Update Angular component to read from all.json and select appropriate changelog data
- Fix missing changelog files in production deployment

## Problem
Production deployment was missing individual changelog files (morphic.json, service.json, extension.json, user.json), causing 404 errors when switching between different changelog views. Only all.json and website.json were present in the deployed container.

## Solution
- Include user changelog data in the combined all.json file
- Update Angular component to load all.json once and select the appropriate component data
- Remove dependency on individual changelog files that may not be built/copied consistently

## Benefits
- **Reliability**: Single file eliminates missing file issues in production
- **Performance**: One HTTP request instead of multiple when switching views
- **Simplicity**: Easier build process without managing multiple output files
- **Consistency**: All changelog data guaranteed to be available

## Changes
- **Build script**: Add user changelog to processedChangelogs object before saving all.json
- **Angular component**: Load all.json and select component data based on current view
- **Deployment**: Only all.json needs to be present for full functionality