### PR TITLE
fix(website): add symlinks for all changelog files in Docker build

### DIFF
--- a/website/EXTENSION_CHANGELOG.md
+++ b/website/EXTENSION_CHANGELOG.md
@@ -1,0 +1,1 @@
+../browser-extension/CHANGELOG.md

--- a/website/MAIN_CHANGELOG.md
+++ b/website/MAIN_CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/website/SERVICE_CHANGELOG.md
+++ b/website/SERVICE_CHANGELOG.md
@@ -1,0 +1,1 @@
+../service/CHANGELOG.md

--- a/website/USER_CHANGELOG.md
+++ b/website/USER_CHANGELOG.md
@@ -1,0 +1,1 @@
+../USER_CHANGELOG.md

--- a/website/scripts/process-changelogs.js
+++ b/website/scripts/process-changelogs.js
@@ -10,13 +10,13 @@ const path = require('path');
 
 // Paths relative to the current working directory (website folder when run via npm)
 const CHANGELOG_PATHS = {
-  'morphic': '../CHANGELOG.md',
-  'service': '../service/CHANGELOG.md', 
+  'morphic': './MAIN_CHANGELOG.md',
+  'service': './SERVICE_CHANGELOG.md', 
   'website': './CHANGELOG.md',
-  'extension': '../browser-extension/CHANGELOG.md'
+  'extension': './EXTENSION_CHANGELOG.md'
 };
 
-const USER_CHANGELOG_PATH = '../USER_CHANGELOG.md';
+const USER_CHANGELOG_PATH = './USER_CHANGELOG.md';
 
 const OUTPUT_DIR = './public/changelogs';
 


### PR DESCRIPTION
## Summary
- Add symlinks in website/ directory to make all changelog files available during Docker builds
- Update build script to use local symlinks instead of relative paths outside Docker context
- Fix missing components in production all.json file

## Problem
The Docker build context was set to `./website` directory only, so the changelog build script couldn't access files like `../CHANGELOG.md`, `../service/CHANGELOG.md`, etc. This resulted in production builds only containing the website component in all.json.

## Solution
Add symlinks in the website directory pointing to all changelog files:
- `MAIN_CHANGELOG.md` → `../CHANGELOG.md`
- `SERVICE_CHANGELOG.md` → `../service/CHANGELOG.md`
- `EXTENSION_CHANGELOG.md` → `../browser-extension/CHANGELOG.md`
- `USER_CHANGELOG.md` → `../USER_CHANGELOG.md`

Update build script to reference these local symlinks instead of relative paths.

## Benefits
- **Complete data**: all.json contains all components (user + technical) in production
- **Clean solution**: No Docker context changes needed, preserves build optimization
- **Consistent naming**: Follows {COMPONENT}_CHANGELOG.md pattern
- **Version controlled**: Symlinks are checked into git for reproducible builds

## Testing
Verified locally that `npm run build:assets` now processes all 5 changelog files correctly.