### PR TITLE
fix(website): use docker build contexts for changelog files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Block everything by default for changelog build context
+*
+
+# Allow only changelog files
+!CHANGELOG.md
+!USER_CHANGELOG.md
+!service/CHANGELOG.md
+!browser-extension/CHANGELOG.md

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -55,6 +55,8 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: ./website
+        build-contexts: |
+          changelogs=.
         platforms: linux/amd64
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ env.IMAGE_PREFIX }}/morphic-website:latest

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,6 +3,12 @@ FROM node:22.16.0-alpine AS builder
 
 WORKDIR /app
 
+# Copy changelog files from changelogs context
+COPY --from=changelogs CHANGELOG.md ./MAIN_CHANGELOG.md
+COPY --from=changelogs service/CHANGELOG.md ./SERVICE_CHANGELOG.md
+COPY --from=changelogs browser-extension/CHANGELOG.md ./EXTENSION_CHANGELOG.md
+COPY --from=changelogs USER_CHANGELOG.md ./USER_CHANGELOG.md
+
 # Copy package files
 COPY package*.json ./
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -23,6 +23,12 @@ COPY --from=changelogs service/CHANGELOG.md ./SERVICE_CHANGELOG.md
 COPY --from=changelogs browser-extension/CHANGELOG.md ./EXTENSION_CHANGELOG.md
 COPY --from=changelogs USER_CHANGELOG.md ./USER_CHANGELOG.md
 
+# Set explicit changelog paths for build script
+ENV MAIN_CHANGELOG_PATH=./MAIN_CHANGELOG.md
+ENV SERVICE_CHANGELOG_PATH=./SERVICE_CHANGELOG.md  
+ENV EXTENSION_CHANGELOG_PATH=./EXTENSION_CHANGELOG.md
+ENV USER_CHANGELOG_PATH=./USER_CHANGELOG.md
+
 # Build Angular app for production
 RUN npm run build -- --configuration=production
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,12 +3,6 @@ FROM node:22.16.0-alpine AS builder
 
 WORKDIR /app
 
-# Copy changelog files from changelogs context
-COPY --from=changelogs CHANGELOG.md ./MAIN_CHANGELOG.md
-COPY --from=changelogs service/CHANGELOG.md ./SERVICE_CHANGELOG.md
-COPY --from=changelogs browser-extension/CHANGELOG.md ./EXTENSION_CHANGELOG.md
-COPY --from=changelogs USER_CHANGELOG.md ./USER_CHANGELOG.md
-
 # Copy package files
 COPY package*.json ./
 
@@ -22,6 +16,12 @@ RUN npm install -g @angular/cli
 
 # Copy source code
 COPY . .
+
+# Copy changelog files from changelogs context (after source to avoid overwriting)
+COPY --from=changelogs CHANGELOG.md ./MAIN_CHANGELOG.md
+COPY --from=changelogs service/CHANGELOG.md ./SERVICE_CHANGELOG.md
+COPY --from=changelogs browser-extension/CHANGELOG.md ./EXTENSION_CHANGELOG.md
+COPY --from=changelogs USER_CHANGELOG.md ./USER_CHANGELOG.md
 
 # Build Angular app for production
 RUN npm run build -- --configuration=production

--- a/website/scripts/process-changelogs.js
+++ b/website/scripts/process-changelogs.js
@@ -9,15 +9,15 @@ const path = require('path');
  */
 
 // Paths relative to the current working directory (website folder when run via npm)
-// Support both local dev (relative paths) and Docker (copied files)
+// Environment variables allow explicit configuration for different build contexts
 const CHANGELOG_PATHS = {
-  'morphic': fs.existsSync('./MAIN_CHANGELOG.md') ? './MAIN_CHANGELOG.md' : '../CHANGELOG.md',
-  'service': fs.existsSync('./SERVICE_CHANGELOG.md') ? './SERVICE_CHANGELOG.md' : '../service/CHANGELOG.md',
+  'morphic': process.env.MAIN_CHANGELOG_PATH || '../CHANGELOG.md',
+  'service': process.env.SERVICE_CHANGELOG_PATH || '../service/CHANGELOG.md',
   'website': './CHANGELOG.md',
-  'extension': fs.existsSync('./EXTENSION_CHANGELOG.md') ? './EXTENSION_CHANGELOG.md' : '../browser-extension/CHANGELOG.md'
+  'extension': process.env.EXTENSION_CHANGELOG_PATH || '../browser-extension/CHANGELOG.md'
 };
 
-const USER_CHANGELOG_PATH = fs.existsSync('./USER_CHANGELOG.md') ? './USER_CHANGELOG.md' : '../USER_CHANGELOG.md';
+const USER_CHANGELOG_PATH = process.env.USER_CHANGELOG_PATH || '../USER_CHANGELOG.md';
 
 const OUTPUT_DIR = './public/changelogs';
 

--- a/website/tsconfig.app.json
+++ b/website/tsconfig.app.json
@@ -11,5 +11,11 @@
   ],
   "include": [
     "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "MAIN_CHANGELOG.md",
+    "SERVICE_CHANGELOG.md",
+    "EXTENSION_CHANGELOG.md", 
+    "USER_CHANGELOG.md"
   ]
 }


### PR DESCRIPTION
## Summary
- Use Docker buildx build-contexts feature to provide changelog files to website build
- Add .dockerignore at repo root to limit changelog context to required files
- Update Dockerfile to copy changelog files from the changelogs context
- Update GitHub Actions workflow to use build-contexts

## Problem
The website Docker build couldn't access changelog files from other components (../CHANGELOG.md, ../service/CHANGELOG.md, etc.) because the build context was limited to the website/ directory. Previous attempts with symlinks failed because Docker couldn't follow symlinks pointing outside the build context.

## Solution
Use Docker buildx's `build-contexts` feature to provide selective access to changelog files:

- **Main context**: `./website` (preserves optimal caching)
- **Changelog context**: `.` (repo root, filtered by .dockerignore)
- **Dockerfile**: Copy files from `changelogs` context early in build

## Benefits
- **Clean separation**: Main build context stays focused on website files
- **Selective access**: Only changelog files are available from repo root
- **Local + CI consistency**: Same build command works everywhere
- **Performance**: Maintains Docker layer caching efficiency
- **Future-proof**: Protected against accidentally including large files

## Implementation
```dockerfile
# Copy changelog files from changelogs context
COPY --from=changelogs CHANGELOG.md ./MAIN_CHANGELOG.md
COPY --from=changelogs service/CHANGELOG.md ./SERVICE_CHANGELOG.md
# etc...
```

```yaml
# GitHub Actions
build-contexts: |
  changelogs=.
```

## Local Testing
```bash
docker buildx build --build-context changelogs=. -f website/Dockerfile website/
```