### PR TITLE
feat(website): add date picker field type to survey forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the Morphic project infrastructure, deployment, and architecture will be documented in this file.
+All notable changes to the Morphic project: application, infrastructure, deployment, and architecture will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Morphic project infrastructure, deployment, and archi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-06-17
+
+### Added
+- **Date Picker Field Type**: New survey field type for collecting date information
+  - Native browser date picker interface for better user experience
+  - Consistent ISO 8601 date format (YYYY-MM-DD) for data storage
+  - Full integration across survey builder, preview, and response collection
+  - Seamless CSV export with properly formatted dates
+
 ## [1.1.0] - 2025-06-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ All form fields use custom Morphic wrapper components (`morphic-text`, `morphic-
 
 ### Survey System Architecture
 - **Survey Creation**: Multi-step survey builder with field validation
-- **Field Types**: Support for text, select (dropdown), radio buttons, and location
+- **Field Types**: Support for text, select (dropdown), radio buttons, location, and date
 - **Location Picker**: Leaflet-based maps with Nominatim geocoding
   - Click-to-place markers
   - Drag-to-move functionality  

--- a/USER_CHANGELOG.md
+++ b/USER_CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Updates and improvements to make your research easier and more efficient.
 
+## [1.2.0] - 2025-06-17
+
+### New Features
+- **Date Picker Fields**: You can now add date fields to your surveys
+  - Select dates using an easy calendar interface
+  - Perfect for time-based research and event tracking
+  - Dates are automatically formatted for consistent data analysis
+
 ## [1.1.0] - 2025-06-16
 
 ### New Features

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Morphic Website will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-06-17
+
+### Added
+- **Date Field Type**: New form field type for date selection in surveys
+  - Native HTML date picker integration  
+  - ISO 8601 date format storage (YYYY-MM-DD)
+  - Full support in survey builder, preview, and response forms
+  - Seamless export functionality with proper date formatting
+
 ## [1.0.1] - 2025-06-15
 
 ### Added

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morphic-website",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "start": "ng serve --host 0.0.0.0",
     

--- a/website/src/app/survey/models/survey.model.ts
+++ b/website/src/app/survey/models/survey.model.ts
@@ -9,13 +9,13 @@ export interface Survey {
 export interface SurveyField {
   id: string;
   label: string;
-  fieldType: 'text' | 'select' | 'radio' | 'location';
+  fieldType: 'text' | 'select' | 'radio' | 'location' | 'date';
   options?: string | string[]; // comma-separated string during creation, array when loaded from backend
   order: number;
 }
 
 export interface FieldType {
-  id: 'text' | 'select' | 'radio' | 'location';
+  id: 'text' | 'select' | 'radio' | 'location' | 'date';
   label: string;
 }
 
@@ -23,5 +23,6 @@ export const FIELD_TYPES: FieldType[] = [
   { id: 'text', label: 'Text' },
   { id: 'select', label: 'Select' },
   { id: 'radio', label: 'Radio' },
-  { id: 'location', label: 'Location' }
+  { id: 'location', label: 'Location' },
+  { id: 'date', label: 'Date' }
 ];

--- a/website/src/app/survey/morphic-date/morphic-date.component.html
+++ b/website/src/app/survey/morphic-date/morphic-date.component.html
@@ -1,0 +1,1 @@
+<p>morphic-date works!</p>

--- a/website/src/app/survey/morphic-date/morphic-date.component.html
+++ b/website/src/app/survey/morphic-date/morphic-date.component.html
@@ -1,1 +1,0 @@
-<p>morphic-date works!</p>

--- a/website/src/app/survey/morphic-date/morphic-date.component.spec.ts
+++ b/website/src/app/survey/morphic-date/morphic-date.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MorphicDateComponent } from './morphic-date.component';
+
+describe('MorphicDateComponent', () => {
+  let component: MorphicDateComponent;
+  let fixture: ComponentFixture<MorphicDateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MorphicDateComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(MorphicDateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/website/src/app/survey/morphic-date/morphic-date.component.ts
+++ b/website/src/app/survey/morphic-date/morphic-date.component.ts
@@ -1,0 +1,67 @@
+import { Component, Input, forwardRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+@Component({
+  selector: 'app-morphic-date',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  template: `
+    <input 
+      type="date"
+      class="form-control"
+      [class.extra]="cssClass"
+      [ngClass]="ngClass"
+      [id]="inputId"
+      [name]="name"
+      [disabled]="disabled"
+      [(ngModel)]="internalValue"
+      (ngModelChange)="onInternalChange()"
+      (blur)="onTouched()">
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MorphicDateComponent),
+      multi: true
+    }
+  ]
+})
+export class MorphicDateComponent implements ControlValueAccessor {
+  @Input({ required: true }) inputId!: string;
+  @Input({ required: true }) name!: string;
+  @Input() disabled: boolean = false;
+  @Input() cssClass?: string;
+  @Input() ngClass?: any;
+
+  // Internal value that HTML date input understands (YYYY-MM-DD format or empty string)
+  internalValue: string = '';
+
+  // ControlValueAccessor implementation
+  private onChange: (value: string | null) => void = () => {};
+  onTouched: () => void = () => {};
+
+  writeValue(value: string | null): void {
+    // Convert null to empty string for HTML input
+    // The value should already be in YYYY-MM-DD format if it exists
+    this.internalValue = value ?? '';
+  }
+
+  registerOnChange(fn: (value: string | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+  }
+
+  onInternalChange(): void {
+    // Convert empty string back to null for Morphic
+    const morphicValue = this.internalValue === '' ? null : this.internalValue;
+    this.onChange(morphicValue);
+  }
+}

--- a/website/src/app/survey/survey-form/survey-form.component.html
+++ b/website/src/app/survey/survey-form/survey-form.component.html
@@ -57,6 +57,16 @@
         </app-location-picker>
       </div>
 
+      <!-- Date Field -->
+      <app-morphic-date *ngIf="field.fieldType === 'date'" 
+                        [ngClass]="{'changed-field': isFieldChanged(field)}"
+                        [inputId]="'field_' + i"
+                        [(ngModel)]="formValues[getFieldKey(field)]"
+                        [name]="'field_' + i"
+                        [disabled]="disabled"
+                        (ngModelChange)="onFieldValueChange(field, $event)">
+      </app-morphic-date>
+
     </div>
 
     <div *ngIf="showSubmitButton && !disabled" class="mt-4">

--- a/website/src/app/survey/survey-form/survey-form.component.ts
+++ b/website/src/app/survey/survey-form/survey-form.component.ts
@@ -7,10 +7,11 @@ import { LocationData } from '../models/location.model';
 import { MorphicTextComponent } from '../form-fields/morphic-text.component';
 import { MorphicSelectComponent } from '../form-fields/morphic-select.component';
 import { MorphicRadioComponent } from '../form-fields/morphic-radio.component';
+import { MorphicDateComponent } from '../morphic-date/morphic-date.component';
 
 @Component({
   selector: 'app-survey-form',
-  imports: [CommonModule, FormsModule, LocationPickerComponent, MorphicTextComponent, MorphicSelectComponent, MorphicRadioComponent],
+  imports: [CommonModule, FormsModule, LocationPickerComponent, MorphicTextComponent, MorphicSelectComponent, MorphicRadioComponent, MorphicDateComponent],
   templateUrl: './survey-form.component.html',
   styleUrls: ['./survey-form.component.css']
 })

--- a/website/src/app/survey/survey-preview/survey-preview.component.html
+++ b/website/src/app/survey/survey-preview/survey-preview.component.html
@@ -45,6 +45,13 @@
         <small class="form-text text-muted">Click on the map to select a location</small>
       </div>
 
+      <!-- Date Field -->
+      <app-morphic-date *ngIf="field.fieldType === 'date'" 
+                        [inputId]="field.id"
+                        [(ngModel)]="previewValues[field.id]"
+                        [name]="field.id">
+      </app-morphic-date>
+
     </div>
 
     <div class="mt-4 p-3 bg-light border rounded">

--- a/website/src/app/survey/survey-preview/survey-preview.component.ts
+++ b/website/src/app/survey/survey-preview/survey-preview.component.ts
@@ -7,10 +7,11 @@ import { LocationData } from '../models/location.model';
 import { MorphicTextComponent } from '../form-fields/morphic-text.component';
 import { MorphicSelectComponent } from '../form-fields/morphic-select.component';
 import { MorphicRadioComponent } from '../form-fields/morphic-radio.component';
+import { MorphicDateComponent } from '../morphic-date/morphic-date.component';
 
 @Component({
   selector: 'app-survey-preview',
-  imports: [CommonModule, FormsModule, LocationPickerComponent, MorphicTextComponent, MorphicSelectComponent, MorphicRadioComponent],
+  imports: [CommonModule, FormsModule, LocationPickerComponent, MorphicTextComponent, MorphicSelectComponent, MorphicRadioComponent, MorphicDateComponent],
   templateUrl: './survey-preview.component.html',
   styleUrls: ['./survey-preview.component.css']
 })


### PR DESCRIPTION
## Summary
- Add new 'date' field type to survey forms alongside existing text, select, radio, and location fields
- Users can now create survey fields that accept date inputs using native HTML date pickers
- Date values are stored as ISO 8601 strings (YYYY-MM-DD format) for consistency and portability

## Changes
- Added 'date' to TypeScript field type union and FIELD_TYPES array
- Created MorphicDateComponent following the same ControlValueAccessor pattern as other form fields
- Updated survey form and preview components to render date fields
- No backend changes required as field_type column already accepts any string value

## Test plan
- [x] Create a new survey with a date field
- [x] Verify date picker appears in survey preview
- [x] Fill out a survey with a date field
- [x] Verify date value is saved correctly
- [x] Verify date value appears correctly when editing responses
- [x] Export survey results and verify date formatting